### PR TITLE
chore: add php 8.5 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-all-issues --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
           - ubuntu-latest
         php-version:
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   test:
@@ -56,12 +57,13 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Lint
+        if: matrix.php-version == '8.4'
         run: |
-          PHP_CS_FIXER_IGNORE_ENV=True vendor/bin/php-cs-fixer fix --diff --dry-run
+          vendor/bin/php-cs-fixer fix --diff --dry-run
 
       - name: PHPUnit
         run: |
-          vendor/bin/phpunit --colors --coverage-text --coverage-clover coverage/clover.xml
+          vendor/bin/phpunit --colors --display-deprecation --coverage-text --coverage-clover coverage/clover.xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@v6

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --display-deprecation --coverage-html ./coverage"
+            "phpunit --colors --display-all-issues --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
             "php-cs-fixer fix -vvv"
         ],
         "test": [
-            "phpunit --colors --coverage-html ./coverage"
+            "phpunit --colors --display-deprecation --coverage-html ./coverage"
         ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "rancoud/security",
-            "version": "4.0.1",
+            "version": "4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rancoud/Security.git",
-                "reference": "2cf4068008957003c274c3d077ee7a2b24903e34"
+                "reference": "4fbc1ee787e1c1e52a5d9c5019e361934a3f4bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rancoud/Security/zipball/2cf4068008957003c274c3d077ee7a2b24903e34",
-                "reference": "2cf4068008957003c274c3d077ee7a2b24903e34",
+                "url": "https://api.github.com/repos/rancoud/Security/zipball/4fbc1ee787e1c1e52a5d9c5019e361934a3f4bed",
+                "reference": "4fbc1ee787e1c1e52a5d9c5019e361934a3f4bed",
                 "shasum": ""
             },
             "require": {
@@ -47,9 +47,9 @@
             "description": "Security package",
             "support": {
                 "issues": "https://github.com/rancoud/Security/issues",
-                "source": "https://github.com/rancoud/Security/tree/4.0.1"
+                "source": "https://github.com/rancoud/Security/tree/4.0.2"
             },
-            "time": "2026-03-15T11:47:47+00:00"
+            "time": "2026-05-31T17:46:21+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -936,37 +936,37 @@ class PaginationTest extends TestCase
     public static function provideExceptionDataCases(): iterable
     {
         yield 'aria_label_nav' => [
-            'conf'    => ['aria_label_nav' => \chr(99999999)],
+            'conf'    => ['aria_label_nav' => "\xFF"],
             'message' => 'could not escAttr "nav" aria label: String to convert is not valid for the specified charset'
         ];
 
         yield 'text_previous' => [
-            'conf'    => ['text_previous' => \chr(99999999), 'always_use_previous' => true],
+            'conf'    => ['text_previous' => "\xFF", 'always_use_previous' => true],
             'message' => 'could not escHTML "previous" text: String to convert is not valid for the specified charset'
         ];
 
         yield 'aria_label_previous' => [
-            'conf'    => ['aria_label_previous' => \chr(99999999), 'always_use_previous' => true],
+            'conf'    => ['aria_label_previous' => "\xFF", 'always_use_previous' => true],
             'message' => 'could not escAttr "previous" aria label or "previous" href: String to convert is not valid for the specified charset'
         ];
 
         yield 'text_next' => [
-            'conf'    => ['text_next' => \chr(99999999), 'always_use_next' => true],
+            'conf'    => ['text_next' => "\xFF", 'always_use_next' => true],
             'message' => 'could not escHTML "next" text: String to convert is not valid for the specified charset'
         ];
 
         yield 'aria_label_next' => [
-            'conf'    => ['aria_label_next' => \chr(99999999), 'always_use_next' => true],
+            'conf'    => ['aria_label_next' => "\xFF", 'always_use_next' => true],
             'message' => 'could not escAttr "next" aria label or "next" href: String to convert is not valid for the specified charset'
         ];
 
         yield 'aria_label_link' => [
-            'conf'    => ['aria_label_link' => \chr(99999999)],
+            'conf'    => ['aria_label_link' => "\xFF"],
             'message' => 'could not escAttr "item" aria label or "item" href: String to convert is not valid for the specified charset'
         ];
 
         yield 'text_page' => [
-            'conf'    => ['text_page' => \chr(99999999)],
+            'conf'    => ['text_page' => "\xFF"],
             'message' => 'could not escHTML "item" text: String to convert is not valid for the specified charset'
         ];
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  
Here are some tips for you:  
1. If this PR is still in in Progress, put it in draft.
2. If this PR is introducing a breaking change please prefix with *BREAKING* in PR title.
3. If this PR has any follow up tasks, please prefix with *TODO* and describe follow up task.
4. When PR is ready to be reviewed, please tag rancoud as a sole reviewer.
-->
# Description
* add php 8.5 to test workflow
* avoid double run on github action
* add `--display-all-issues` on phpunit command
* remove lint action on php 8.5
* remove `PHP_CS_FIXER_IGNORE_ENV=True` for lint
* update dependency `rancoud/security` from `4.0.1` to `4.0.2`